### PR TITLE
Adjust trade queries to require available listings

### DIFF
--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -1068,7 +1068,7 @@ function TradeQueryClass:UpdateRealms()
 	end
 
 	-- perform a generic search to make sure POESESSID if valid.
-	self.tradeQueryRequests:PerformSearch("poe2", "Standard", [[{"query":{"status":{"option":"online"},"stats":[{"type":"and","filters":[]}]},"sort":{"price":"asc"}}]], function(response, errMsg) 
+	self.tradeQueryRequests:PerformSearch("poe2", "Standard", [[{"query":{"status":{"option":"available"},"stats":[{"type":"and","filters":[]}]},"sort":{"price":"asc"}}]], function(response, errMsg)
 		if errMsg then
 			self:SetNotice(self.controls.pbNotice, "Error: " .. tostring(errMsg))
 		end

--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -829,7 +829,7 @@ function TradeQueryGeneratorClass:FinishQuery()
 					}
 				}
 			},
-			status = { option = "online" },
+			status = { option = "available" },
 			stats = {
 				{
 					type = "weight",

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -1934,8 +1934,8 @@ function TreeTabClass:FindTimelessJewel()
 
 		local search = {
 			query = {
-				status = {
-					option = "online"
+			status = {
+				option = "available"
 				},
 				stats = {
 					{


### PR DESCRIPTION
## Summary
- request available listings when generating weighted trade queries
- update the timeless jewel search helper to use the available status filter
- ensure the POESESSID validation query also requests available listings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb7aa42550832fb0a4aa6c65b8231b